### PR TITLE
use List::MoreUtils uniq for legacy compatibility

### DIFF
--- a/duprule.pl
+++ b/duprule.pl
@@ -1,7 +1,7 @@
 package DupRules;
 use strict;
 use warnings;
-use List::Util qw(uniq);
+use List::MoreUtils qw(uniq);
 use Data::Dumper;
 
 sub new {


### PR DESCRIPTION
There is currently a dependency on a newer version of List::Util than the one that ships with Ubuntu 16.04 LTS

$ perl ./duprule.pl
"uniq" is not exported by the List::Util module
Can't continue after import errors at ./duprule.pl line 4.
BEGIN failed--compilation aborted at ./duprule.pl line 4.

Options include:

* switching to a standalone implementation of uniq

* requiring List::Util 1.44 and giving a warning

* requiring List::MoreUtils instead (not included with Perl, but packaged as liblist-moreutils-perl in Ubuntu)